### PR TITLE
2x bugfix

### DIFF
--- a/docs/doh.md
+++ b/docs/doh.md
@@ -8,15 +8,24 @@ Usage: doh [options] [host name] [URL]
 
 ### --A
 
-Ask for a type A resource. (default)
+Ask for a set of type A resource records. (default)
 
 ### --AAAA
 
-Ask for a type AAAA resource.
+Ask for a set of type AAAA resource records.
 
 ### --NS
 
-Ask for a type NS resource.
+Ask for a set of type NS resource records.
+
+### --TXT
+
+Ask for a set of type TXT resource records.
+
+### --TYPEnum
+
+Ask for a set of resource records of arbitrary numeric type **num**,
+in range [1..65535].
 
 ### --help
 
@@ -42,3 +51,33 @@ Show usage message
     00000010  6d 70 6c 65 03 63 6f 6d  00 00 1c 00 01 c0 0c 00  |mple.com........|
     00000020  1c 00 01 00 00 00 c4 00  10 26 06 28 00 02 20 00  |.........&.(.. .|
     00000030  01 02 48 18 93 25 c8 19  46                       |..H..%..F|
+
+    $ ./doh --TXT _esni.only.esni.defo.ie \
+	        https://dns.cloudflare.com/.well-known/dns-query | hd
+	00000000  00 00 81 a0 00 01 00 01  00 00 00 01 05 5f 65 73  |............._es|
+	00000010  6e 69 04 6f 6e 6c 79 04  65 73 6e 69 04 64 65 66  |ni.only.esni.def|
+	00000020  6f 02 69 65 00 00 10 00  01 c0 0c 00 10 00 01 00  |o.ie............|
+	00000030  00 06 f7 00 5d 5c 2f 77  46 38 4e 30 37 37 41 43  |....]\/wF8N077AC|
+	00000040  51 41 48 51 41 67 4e 67  79 67 51 63 46 72 77 47  |QAHQAgNgygQcFrwG|
+	00000050  6a 65 61 32 37 68 34 6c  49 38 54 77 4b 58 68 42  |jea27h4lI8TwKXhB|
+	00000060  49 69 44 55 33 59 75 68  32 6a 62 75 55 46 32 30  |IiDU3Yuh2jbuUF20|
+	00000070  63 41 41 68 4d 42 41 51  51 41 41 41 41 41 58 56  |cAAhMBAQQAAAAAXV|
+	00000080  73 65 4f 41 41 41 41 41  42 64 57 7a 4e 51 41 41  |seOAAAAABdWzNQAA|
+	00000090  41 3d 00 00 29 05 ac 00  00 00 00 00 63 00 0c 00  |A=..).......c...|
+	000000a0  5f 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |_...............|
+	000000b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
+
+    $ ./doh --TYPE16 _esni.only.esni.defo.ie \
+	        https://dns.cloudflare.com/.well-known/dns-query | hd
+	00000000  00 00 81 a0 00 01 00 01  00 00 00 01 05 5f 65 73  |............._es|
+	00000010  6e 69 04 6f 6e 6c 79 04  65 73 6e 69 04 64 65 66  |ni.only.esni.def|
+	00000020  6f 02 69 65 00 00 10 00  01 c0 0c 00 10 00 01 00  |o.ie............|
+	00000030  00 07 08 00 5d 5c 2f 77  46 38 4e 30 37 37 41 43  |....]\/wF8N077AC|
+	00000040  51 41 48 51 41 67 4e 67  79 67 51 63 46 72 77 47  |QAHQAgNgygQcFrwG|
+	00000050  6a 65 61 32 37 68 34 6c  49 38 54 77 4b 58 68 42  |jea27h4lI8TwKXhB|
+	00000060  49 69 44 55 33 59 75 68  32 6a 62 75 55 46 32 30  |IiDU3Yuh2jbuUF20|
+	00000070  63 41 41 68 4d 42 41 51  51 41 41 41 41 41 58 56  |cAAhMBAQQAAAAAXV|
+	00000080  73 65 4f 41 41 41 41 41  42 64 57 7a 4e 51 41 41  |seOAAAAABdWzNQAA|
+	00000090  41 3d 00 00 29 05 ac 00  00 00 00 00 63 00 0c 00  |A=..).......c...|
+	000000a0  5f 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |_...............|
+	000000b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|

--- a/doh
+++ b/doh
@@ -10,13 +10,23 @@ sub help {
         " --A       encode a type A request (default)\n",
         " --AAAA    encode a type AAAA request\n",
         " --CNAME   encode a type CNAME request\n",
-        " --NS      encode a type NS request\n";
+        " --NS      encode a type NS request\n",
+        " --TXT     encode a type TXT request\n",
+        " --TYPEnum (or --type=num)\n",
+	"           encode a type <num> request (num in [1..65535])\n",
+	"\n",
+	"Notes:\n",
+	" 1. ESNI data may appear as TXT records using prefix '_esni.'\n",
+	"    or as TYPE65439 records using the host name without prefix.\n",
+	" 2. Not all DOH servers accept queries which specify TYPE65439.\n",
+	"\n";
     exit;
 }
 
 my %dnstype = (1 => "A",
                2 => "NS",
                5 => "CNAME",
+	       16 => "TXT",
                28 => "AAAA");
 
 my $host;
@@ -41,6 +51,17 @@ while($ARGV[0]) {
     elsif($ARGV[0] eq "--CNAME") {
         $type=5;
         shift @ARGV;
+    }
+    elsif($ARGV[0] eq "--TXT") {
+	$type=16;
+	shift @ARGV;
+    }
+    elsif((($ARGV[0] =~ /^--TYPE([0-9]+)$/) ||
+	   ($ARGV[0] =~ /^--type=([0-9]+)$/)) &&
+	  (int($1) > 0) &&
+	  (int($1) < 2**16)) {
+	$type=int($1);
+	shift @ARGV;
     }
     elsif(($ARGV[0] eq "--help") ||
           ($ARGV[0] eq "-h")) {

--- a/doh
+++ b/doh
@@ -140,7 +140,7 @@ my $qname = QNAME($host);
 my $qnameptr =  sprintf("\xc0\x0c", $answers);
 my $ancount = sprintf("\x00%c", $answers);
 my $qdcount = sprintf("\x00%c", 1); # questions
-my $qtype = sprintf("\x00%c", $type); # for now
+my $qtype = sprintf("%c%c", $type >> 8, $type & 255);
 my $ttl = pack 'N', $seconds;
 
 my $header;
@@ -162,7 +162,8 @@ $msg = "$header$question";
 
 my $output = encode("iso-8859-1", "$msg");
 
-open(CURL, "|curl -s --data-binary \@- -H 'Content-Type: application/dns-udpwireformat' $url -o-");
+open(CURL, "|curl -s --data-binary \@- -H 'Content-Type: application/dns-message' $url -o-");
+
 print CURL $output;
 close(CURL);
 


### PR DESCRIPTION
- encode QTYPE without setting high octet to zero
- use 'Content-Type: application/dns-message' (RFC8484) as some servers don't (or no longer) support 'application/dns-udpwireformat'